### PR TITLE
feat: 무한스크롤 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,6 +5,7 @@
       <map>
         <entry key="..\:/Users/SSAFY/GitHub/kotlin-github-search-project/app/src/main/res/layout/activity_main.xml" value="0.2703804347826087" />
         <entry key="..\:/Users/SSAFY/GitHub/kotlin-github-search-project/app/src/main/res/layout/list_item_git.xml" value="0.2703804347826087" />
+        <entry key="..\:/Users/SSAFY/GitHub/kotlin-github-search-project/app/src/main/res/layout/list_item_loading.xml" value="0.25769927536231885" />
         <entry key="..\:/Users/SSAFY/GitHub/kotlin-github-search-project/app/src/main/res/layout/list_item_repo.xml" value="0.26403985507246375" />
       </map>
     </option>

--- a/app/src/main/java/com/juhwan/github_search_project/config/ApplicationClass.kt
+++ b/app/src/main/java/com/juhwan/github_search_project/config/ApplicationClass.kt
@@ -9,6 +9,7 @@ class ApplicationClass : Application() {
 
     companion object {
         lateinit var retrofit: Retrofit
+        val PER_PAGE = 10
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/juhwan/github_search_project/repository/RepoRepository.kt
+++ b/app/src/main/java/com/juhwan/github_search_project/repository/RepoRepository.kt
@@ -1,6 +1,7 @@
 package com.juhwan.github_search_project.repository
 
 import android.util.Log
+import com.juhwan.github_search_project.config.ApplicationClass.Companion.PER_PAGE
 import com.juhwan.github_search_project.dto.RepoDto
 import com.juhwan.github_search_project.util.RetrofitCallback
 import com.juhwan.github_search_project.util.RetrofitUtil
@@ -9,23 +10,21 @@ import retrofit2.Callback
 import retrofit2.Response
 
 object RepoRepository {
-    fun selectAllRepos(q: String, per_page: Int, page: Int, callback: RetrofitCallback<RepoDto>) {
-        RetrofitUtil.repoService.selectAllRepos(q, per_page.toString(), page.toString()).enqueue(object: Callback<RepoDto> {
+    fun selectAllRepos(q: String, page: Int, callback: RetrofitCallback<RepoDto>) {
+        RetrofitUtil.repoService.selectAllRepos(q, PER_PAGE.toString(), page.toString()).enqueue(object: Callback<RepoDto> {
             override fun onResponse(
                 call: Call<RepoDto>,
                 response: Response<RepoDto>
             ) {
-                if (response.isSuccessful) {
-                    try {
-                        callback.onSuccess(response.code(), response.body()!!)
-                    } catch (e: Exception){
-                        callback.onFailure(response.code())
-                    }
+                if (response.code() == 200) {
+                    callback.onSuccess(response.code(), response.body()!!)
+                } else {
+                    callback.onError(response.code())
                 }
             }
 
             override fun onFailure(call: Call<RepoDto>, t: Throwable) {
-                callback.onError(t)
+                callback.onFailure(t)
             }
         })
     }

--- a/app/src/main/java/com/juhwan/github_search_project/src/MainActivity.kt
+++ b/app/src/main/java/com/juhwan/github_search_project/src/MainActivity.kt
@@ -11,11 +11,14 @@ import com.juhwan.github_search_project.repository.RepoRepository
 import com.juhwan.github_search_project.util.RetrofitCallback
 import android.widget.EditText
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 
-private const val TAG = "MainActivity_juhwan"
+private const val TAG = "싸피"
+private var page = 1
 
 class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
     lateinit var repoAdapter: RepoAdapter
+    private var query = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -24,7 +27,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
         initEvent()
     }
 
-    fun initView() {
+    private fun initView() {
         val searchEditText = binding.svRepo.findViewById<EditText>(androidx.appcompat.R.id.search_src_text)
         searchEditText.setTextColor(resources.getColor(R.color.white))
         searchEditText.setHintTextColor(resources.getColor(R.color.white))
@@ -36,26 +39,47 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
         }
     }
 
-    fun initEvent() {
+    private fun initEvent() {
         binding.svRepo.setOnQueryTextListener(
             object : SearchView.OnQueryTextListener{
                 override fun onQueryTextSubmit(query: String?): Boolean {
-                    RepoRepository.selectAllRepos(query ?: "", 10, 1, getRepoCallback())
+                    this@MainActivity.query = query ?: ""
+                    page = 1
+                    selectAllRepos()
                     return false
                 }
                 override fun onQueryTextChange(newText: String?): Boolean {
                     return false
                 }
             })
+
+        binding.rvRepo.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                super.onScrolled(recyclerView, dx, dy)
+
+                val lastVisibleItemPosition =
+                    (recyclerView.layoutManager as LinearLayoutManager?)!!.findLastCompletelyVisibleItemPosition()
+                val itemTotalCount = recyclerView.adapter!!.itemCount
+
+                if (!binding.rvRepo.canScrollVertically(1) &&
+                    lastVisibleItemPosition == itemTotalCount - 1) {
+                    selectAllRepos()
+                }
+            }
+        })
     }
 
-    inner class getRepoCallback: RetrofitCallback<RepoDto> {
+    private fun selectAllRepos() {
+        RepoRepository.selectAllRepos(query, page, RepoCallback())
+    }
+
+    inner class RepoCallback: RetrofitCallback<RepoDto> {
         override fun onSuccess(
             code: Int,
             responseData: RepoDto
         ) {
             if(responseData != null) {
-                repoAdapter.concatList(responseData.items)
+                repoAdapter.loadMorePage(responseData.items, page++)
                 Log.d(TAG, "onSuccess: ${responseData.items.size} repositories received")
             } else {
                 showToastMessage("검색결과가 없습니다")
@@ -63,12 +87,12 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
             }
         }
 
-        override fun onError(t: Throwable) {
-            Log.d(TAG, t.message ?: "onError")
+        override fun onFailure(t: Throwable) {
+            Log.d(TAG, t.message ?: "onFailure")
         }
 
-        override fun onFailure(code: Int) {
-            Log.d(TAG, "onFailure: Error Code $code")
+        override fun onError(code: Int) {
+            Log.d(TAG, "onError: Error Code $code")
         }
     }
 }

--- a/app/src/main/java/com/juhwan/github_search_project/src/RepoAdapter.kt
+++ b/app/src/main/java/com/juhwan/github_search_project/src/RepoAdapter.kt
@@ -1,16 +1,18 @@
 package com.juhwan.github_search_project.src
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.juhwan.github_search_project.config.ApplicationClass.Companion.PER_PAGE
 import com.juhwan.github_search_project.databinding.ListItemRepoBinding
 import com.juhwan.github_search_project.dto.Item
 
-class RepoAdapter() : RecyclerView.Adapter<RepoAdapter.RepoViewHolder>() {
-    var repoList = mutableListOf<Item>()
+class RepoAdapter : RecyclerView.Adapter<RepoAdapter.RepoViewHolder>() {
+    var repoList = mutableListOf<Item?>()
 
     inner class RepoViewHolder(private val binding: ListItemRepoBinding) : RecyclerView.ViewHolder(binding.root) {
-        fun bindInfo(item: Item) {
+        fun bindInfo(item: Item?) {
             binding.item = item
         }
     }
@@ -26,8 +28,26 @@ class RepoAdapter() : RecyclerView.Adapter<RepoAdapter.RepoViewHolder>() {
 
     override fun getItemCount(): Int = repoList.size
 
-    fun concatList(list: List<Item>) {
+    fun loadMorePage (list: List<Item>, page: Int) {
+        // 2페이지 이상 불러올때는 먼저 ProgressBar Item을 삭제한다.
+        if(page > 1) {
+            repoList.removeAt((page - 1) * 10)
+            notifyItemRemoved((page - 1) * 10)
+        }
+
+        // 새로운 페이지 Item들을 넣고
         repoList.addAll(list)
-        notifyDataSetChanged()
+
+        // 새로운 Item들이 10개라면
+        if(list.size == PER_PAGE) {
+            // ProgressBar를 위치할 비어있는 Item을 넣어주고
+            repoList.add(null)
+            notifyItemRangeInserted((page - 1) * 10, PER_PAGE + 1)
+        }
+
+        // 새로운 Item들이 10개 미만 이라면
+        else {
+            notifyItemRangeInserted((page - 1) * 10, list.size)
+        }
     }
 }

--- a/app/src/main/java/com/juhwan/github_search_project/util/ImageBindingAdapter.kt
+++ b/app/src/main/java/com/juhwan/github_search_project/util/ImageBindingAdapter.kt
@@ -8,9 +8,10 @@ object ImageBindingAdapter {
     @JvmStatic
     @BindingAdapter("setImageByGlide")
     fun setImageByGlide(view: ImageView, url: String){
-        Glide.with(view.context)
-            .load(url)
-            .override(80, 80)
-            .into(view)
+        if(url.isNotEmpty()) {
+            Glide.with(view.context)
+                .load(url)
+                .into(view)
+        }
     }
 }

--- a/app/src/main/java/com/juhwan/github_search_project/util/ImageBindingAdapter.kt
+++ b/app/src/main/java/com/juhwan/github_search_project/util/ImageBindingAdapter.kt
@@ -1,5 +1,6 @@
 package com.juhwan.github_search_project.util
 
+import android.util.Log
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
@@ -8,7 +9,11 @@ object ImageBindingAdapter {
     @JvmStatic
     @BindingAdapter("setImageByGlide")
     fun setImageByGlide(view: ImageView, url: String){
-        if(url.isNotEmpty()) {
+        if(url.isEmpty()) {
+            Glide.with(view.context)
+                .load("https://user-images.githubusercontent.com/76620764/148633216-6f17ddc8-9f1e-4666-b4a0-2c41e01a7314.png")
+                .into(view)
+        } else {
             Glide.with(view.context)
                 .load(url)
                 .into(view)

--- a/app/src/main/java/com/juhwan/github_search_project/util/RetrofitCallback.kt
+++ b/app/src/main/java/com/juhwan/github_search_project/util/RetrofitCallback.kt
@@ -1,9 +1,9 @@
 package com.juhwan.github_search_project.util
 
 interface RetrofitCallback<T> {
-    fun onError(t: Throwable)
+    fun onError(code: Int)
 
     fun onSuccess(code: Int, responseData: T)
 
-    fun onFailure(code: Int)
+    fun onFailure(t: Throwable)
 }

--- a/app/src/main/res/layout/list_item_repo.xml
+++ b/app/src/main/res/layout/list_item_repo.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <import type="android.view.View"/>
         <variable
             name="item"
             type="com.juhwan.github_search_project.dto.Item" />
@@ -15,10 +16,10 @@
 
         <ImageView
             android:id="@+id/iv_avatar"
-            android:layout_width="80dp"
-            android:layout_height="80dp"
+            android:layout_width="75dp"
+            android:layout_height="75dp"
             android:layout_margin="@dimen/activity_margin_default"
-            app:setImageByGlide="@{item.owner.avatar_url}"
+            app:setImageByGlide='@{item.owner.avatar_url ?? ""}'
             tools:srcCompat="@tools:sample/avatars"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -28,7 +29,7 @@
             style="@style/header_text"
             android:id="@+id/tv_full_name"
             android:layout_margin="@dimen/activity_margin_default"
-            android:text="@{item.full_name}"
+            android:text='@{item.full_name}'
             tools:text="juhwankim-dev/Algorithm"
             app:layout_constraintStart_toEndOf="@+id/iv_avatar"
             app:layout_constraintTop_toTopOf="@+id/iv_avatar" />
@@ -37,9 +38,20 @@
             style="@style/body_text"
             android:id="@+id/tv_language"
             android:layout_margin="@dimen/activity_margin_default"
-            android:text="@{item.language}"
+            android:text='@{item.language}'
             tools:text="Java"
             app:layout_constraintBottom_toBottomOf="@+id/iv_avatar"
             app:layout_constraintStart_toEndOf="@+id/iv_avatar" />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="@{item == null ? View.VISIBLE : View.GONE}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## 무한스크롤
- Resolves #8 
<img src="https://user-images.githubusercontent.com/76620764/148633553-bc2f83f4-9a41-426c-a2f4-7c6d8205911d.gif" height="600"/>

<br>

## 핵심코드
- 스크롤이 최하단에 도달하면 다음 페이지를 request함 (selectAllRepos 호출)
- 현재 보이는 마지막 아이템의 `Position`을 한 번 더 검사하여 `2중으로 하단 감지` 체크
```
        binding.rvRepo.addOnScrollListener(object : RecyclerView.OnScrollListener() {
            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                super.onScrolled(recyclerView, dx, dy)

                val lastVisibleItemPosition =
                    (recyclerView.layoutManager as LinearLayoutManager?)!!.findLastCompletelyVisibleItemPosition()
                val itemTotalCount = recyclerView.adapter!!.itemCount

                if (!binding.rvRepo.canScrollVertically(1) &&
                    lastVisibleItemPosition == itemTotalCount - 1) {
                    selectAllRepos()
                }
            }
        })
```

<br>

- list item에 Repository의 정보와 `ProgressBar`를 동시에 위치
![20220108_150928](https://user-images.githubusercontent.com/76620764/148633695-487724f8-dc22-442f-83cf-35f54f99dae9.png)

<br>

- null check를 통해 `VISIBLE` 관리
```
        <ProgressBar
            android:id="@+id/progressBar"
            style="?android:attr/progressBarStyle"
            android:layout_width="wrap_content"
            android:layout_height="wrap_content"
            android:visibility="@{item == null ? View.VISIBLE : View.GONE}"
            app:layout_constraintBottom_toBottomOf="parent"
            app:layout_constraintEnd_toEndOf="parent"
            app:layout_constraintStart_toStartOf="parent"
            app:layout_constraintTop_toTopOf="parent" />
```

<br>

- Item 개수에 따라 끝에 `ProgressBar`를 위치시키기 위해 `null`을 삽입
- 페이지를 불러오기 전 null Item을 먼저 삭제
```
    fun loadMorePage (list: List<Item>, page: Int) {
        // 2페이지 이상 불러올때는 먼저 ProgressBar Item을 삭제한다.
        if(page > 1) {
            repoList.removeAt((page - 1) * 10)
            notifyItemRemoved((page - 1) * 10)
        }

        // 새로운 페이지 Item들을 넣고
        repoList.addAll(list)

        // 새로운 Item들이 10개라면
        if(list.size == PER_PAGE) {
            // ProgressBar를 위치할 비어있는 Item을 넣어주고
            repoList.add(null)
            notifyItemRangeInserted((page - 1) * 10, PER_PAGE + 1)
        }

        // 새로운 Item들이 10개 미만 이라면
        else {
            notifyItemRangeInserted((page - 1) * 10, list.size)
        }
    }
```

<br>

## 버그 수정
- Resolves #9 
- [Glide 공식문서](http://bumptech.github.io/glide/doc/caching.html)에서 힌트를 얻어 마지막 Item이 보이기 전 `캐시`를 삭제해보았으나 여전히 문제가 발생
- `notifyItemRemoved`, `notifyItemRangeInserted`와 관련된 이슈일까 하여 조사해보았지만 문제 X
- Log를 찍어 해당 Item에 url이 들어가지 않는 것을 확실하게 확인
- url이 비어있으면 `흰색 배경`을 띄우는 대안으로 해결
<img src="https://user-images.githubusercontent.com/76620764/148633897-c0aa512b-2465-4e75-93c6-1799141dd23d.gif" height="600"/>