### PR TITLE
feat: 재검색 기능 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,7 +6,7 @@
         <entry key="..\:/Users/SSAFY/GitHub/kotlin-github-search-project/app/src/main/res/layout/activity_main.xml" value="0.2703804347826087" />
         <entry key="..\:/Users/SSAFY/GitHub/kotlin-github-search-project/app/src/main/res/layout/list_item_git.xml" value="0.2703804347826087" />
         <entry key="..\:/Users/SSAFY/GitHub/kotlin-github-search-project/app/src/main/res/layout/list_item_loading.xml" value="0.25769927536231885" />
-        <entry key="..\:/Users/SSAFY/GitHub/kotlin-github-search-project/app/src/main/res/layout/list_item_repo.xml" value="0.26403985507246375" />
+        <entry key="..\:/Users/SSAFY/GitHub/kotlin-github-search-project/app/src/main/res/layout/list_item_repo.xml" value="0.5" />
       </map>
     </option>
   </component>

--- a/app/src/main/java/com/juhwan/github_search_project/src/MainActivity.kt
+++ b/app/src/main/java/com/juhwan/github_search_project/src/MainActivity.kt
@@ -12,6 +12,7 @@ import com.juhwan.github_search_project.util.RetrofitCallback
 import android.widget.EditText
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import android.widget.Toast
 
 private const val TAG = "싸피"
 private var page = 1
@@ -45,6 +46,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                 override fun onQueryTextSubmit(query: String?): Boolean {
                     this@MainActivity.query = query ?: ""
                     page = 1
+                    repoAdapter.reset()
                     selectAllRepos()
                     return false
                 }
@@ -82,8 +84,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                 repoAdapter.loadMorePage(responseData.items, page++)
                 Log.d(TAG, "onSuccess: ${responseData.items.size} repositories received")
             } else {
-                showToastMessage("검색결과가 없습니다")
-                Log.d(TAG, "onSuccess: no responseData")
+                Log.d(TAG, "onSuccess: responseData is null")
             }
         }
 

--- a/app/src/main/java/com/juhwan/github_search_project/src/MainActivity.kt
+++ b/app/src/main/java/com/juhwan/github_search_project/src/MainActivity.kt
@@ -63,7 +63,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                     (recyclerView.layoutManager as LinearLayoutManager?)!!.findLastCompletelyVisibleItemPosition()
                 val itemTotalCount = recyclerView.adapter!!.itemCount
 
-                if (!binding.rvRepo.canScrollVertically(1) &&
+                if (lastVisibleItemPosition > 0 &&
+                    !binding.rvRepo.canScrollVertically(1) &&
                     lastVisibleItemPosition == itemTotalCount - 1) {
                     selectAllRepos()
                 }

--- a/app/src/main/java/com/juhwan/github_search_project/src/RepoAdapter.kt
+++ b/app/src/main/java/com/juhwan/github_search_project/src/RepoAdapter.kt
@@ -50,4 +50,9 @@ class RepoAdapter : RecyclerView.Adapter<RepoAdapter.RepoViewHolder>() {
             notifyItemRangeInserted((page - 1) * 10, list.size)
         }
     }
+
+    fun reset() {
+        repoList.clear()
+        notifyDataSetChanged()
+    }
 }

--- a/app/src/main/res/layout/list_item_repo.xml
+++ b/app/src/main/res/layout/list_item_repo.xml
@@ -28,9 +28,13 @@
         <TextView
             style="@style/header_text"
             android:id="@+id/tv_full_name"
+            android:layout_width="0dp"
             android:layout_margin="@dimen/activity_margin_default"
+            android:maxLines="1"
+            android:ellipsize="end"
             android:text='@{item.full_name}'
             tools:text="juhwankim-dev/Algorithm"
+            app:layout_constraintWidth_percent="0.7"
             app:layout_constraintStart_toEndOf="@+id/iv_avatar"
             app:layout_constraintTop_toTopOf="@+id/iv_avatar" />
 


### PR DESCRIPTION
## 재검색

- Resolves #11 
<img src="https://user-images.githubusercontent.com/76620764/148637038-5aca5289-cb8e-42f1-bc22-4259bd891e14.gif" height="600"/>

<br>

## 핵심코드

- searchView의 검색 버튼 클릭 시 adapter에 있는 아래 메서드를 호출하여 초기화

```
    fun reset() {
        repoList.clear()
        notifyDataSetChanged()
    }
```

<br>

## 버그 수정
- Resolves #12 
- 재검색 시 리스트가 지워진 직후 Item의 개수가 0일 때 기존의 하단 감지 로직을 통과하는 현상을 발견함
- Item 개수가 0이라서 이미 하단에 도달한 것으로 인식했던 것이 원인

```
                if (!binding.rvRepo.canScrollVertically(1) &&
                    lastVisibleItemPosition == itemTotalCount - 1) {
                    selectAllRepos()
                }
```

<br>

- 조건을 하나 더 추가함으로써 간단하게 해결
```
                if (lastVisibleItemPosition > 0 &&
                    !binding.rvRepo.canScrollVertically(1) &&
                    lastVisibleItemPosition == itemTotalCount - 1) {
                    selectAllRepos()
                }
```